### PR TITLE
Add ability to choose compilers via mixin.

### DIFF
--- a/compiler-chooser.mixin
+++ b/compiler-chooser.mixin
@@ -1,22 +1,40 @@
 {
     "build": {
-        "gcc8": {
-          "cmake-args": ["-DCMAKE_CXX_COMPILER=g++-8", "-DCMAKE_C_COMPILER=gcc8"]
-        },
-        "gcc7": {
-          "cmake-args": ["-DCMAKE_CXX_COMPILER=g++-7", "-DCMAKE_C_COMPILER=gcc7"]
-        },
-        "gcc6": {
-          "cmake-args": ["-DCMAKE_CXX_COMPILER=g++-6", "-DCMAKE_C_COMPILER=gcc6"]
-        },
-        "clang6": {
-          "cmake-args": ["-DCMAKE_CXX_COMPILER=clang++-6", "-DCMAKE_C_COMPILER=clang6"]
+        "clang4": {
+            "cmake-args": [
+                "-DCMAKE_CXX_COMPILER=clang++-4",
+                "-DCMAKE_C_COMPILER=clang4"
+            ]
         },
         "clang5": {
-          "cmake-args": ["-DCMAKE_CXX_COMPILER=clang++-5", "-DCMAKE_C_COMPILER=clang5"]
+            "cmake-args": [
+                "-DCMAKE_CXX_COMPILER=clang++-5",
+                "-DCMAKE_C_COMPILER=clang5"
+            ]
         },
-        "clang4": {
-          "cmake-args": ["-DCMAKE_CXX_COMPILER=clang++-4", "-DCMAKE_C_COMPILER=clang4"]
+        "clang6": {
+            "cmake-args": [
+                "-DCMAKE_CXX_COMPILER=clang++-6",
+                "-DCMAKE_C_COMPILER=clang6"
+            ]
+        },
+        "gcc6": {
+            "cmake-args": [
+                "-DCMAKE_CXX_COMPILER=g++-6",
+                "-DCMAKE_C_COMPILER=gcc6"
+            ]
+        },
+        "gcc7": {
+            "cmake-args": [
+                "-DCMAKE_CXX_COMPILER=g++-7",
+                "-DCMAKE_C_COMPILER=gcc7"
+            ]
+        },
+        "gcc8": {
+            "cmake-args": [
+                "-DCMAKE_CXX_COMPILER=g++-8",
+                "-DCMAKE_C_COMPILER=gcc8"
+            ]
         }
+    }
 }
-

--- a/compiler-chooser.mixin
+++ b/compiler-chooser.mixin
@@ -1,0 +1,22 @@
+{
+    "build": {
+        "gcc8": {
+          "cmake-args": ["-DCMAKE_CXX_COMPILER=g++-8", "-DCMAKE_C_COMPILER=gcc8"]
+        },
+        "gcc7": {
+          "cmake-args": ["-DCMAKE_CXX_COMPILER=g++-7", "-DCMAKE_C_COMPILER=gcc7"]
+        },
+        "gcc6": {
+          "cmake-args": ["-DCMAKE_CXX_COMPILER=g++-6", "-DCMAKE_C_COMPILER=gcc6"]
+        },
+        "clang6": {
+          "cmake-args": ["-DCMAKE_CXX_COMPILER=clang++-6", "-DCMAKE_C_COMPILER=clang6"]
+        },
+        "clang5": {
+          "cmake-args": ["-DCMAKE_CXX_COMPILER=clang++-5", "-DCMAKE_C_COMPILER=clang5"]
+        },
+        "clang4": {
+          "cmake-args": ["-DCMAKE_CXX_COMPILER=clang++-4", "-DCMAKE_C_COMPILER=clang4"]
+        }
+}
+

--- a/index.yaml
+++ b/index.yaml
@@ -1,1 +1,2 @@
 mixin:
+    - compiler-chooser.yaml


### PR DESCRIPTION
This seems to be a common use case for me, as gz11 requires GCC8.