### PR TITLE
Add a mixin for GCC coverage flags

### DIFF
--- a/coverage.mixin
+++ b/coverage.mixin
@@ -1,0 +1,10 @@
+{
+    "build": {
+        "coverage": {
+            "cmake-args": [
+                "-DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage -DCOVERAGE_RUN=1'",
+                "-DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage -DCOVERAGE_RUN=1'"
+            ]
+        }
+    }
+}

--- a/index.yaml
+++ b/index.yaml
@@ -2,4 +2,5 @@ mixin:
   - build-testing.mixin
   - build-type.mixin
   - ccache.mixin
+  - coverage.mixin
   - test-linters.mixin

--- a/lint.py
+++ b/lint.py
@@ -23,7 +23,8 @@ for name in sorted(os.listdir()):
             'rules: {'
             'document-start: {present: false}, '
             'empty-lines: {max: 0}, '
-            'key-ordering: {}'
+            'key-ordering: {}, '
+            'line-length: {max: 999}'
             '}'
             '}',
             '--strict',


### PR DESCRIPTION
## How to use
1. Build
```bash
$ colcon build --mixin coverage
$ find ./build -name "*.gcno"
# a gcno for each source file that was built
$ rm $(find ./build -name "CMake*CompilerId.gcno")
# These are created by the CMake compiler checker
$ mkdir lcov
```

2. (Optional) Generate baseline zero-coverage using `lcov --initial ...`
```bash
$ lcov \
    --base-directory .  \
    --initial \
    --capture \
    --directory ./build \
    --output-file ./lcov/zero-coverage \
    --no-external \
    --rc lcov_branch_coverage=1
```

3. Run tests
```bash
$ colcon test
$ find ./build -name "*.gcda"
# a gcda for each source file whose code was executed
```

4. Use lcov to generate coverage output
```bash
$ lcov \
    --base-directory . \
    --capture \
    --directory ./build \
    --output-file lcov/coverage \
    --no-external \
    --rc lcov_branch_coverage=1
```

5. (optional) Combine zero-coverage (from step 2) with coverage output (from step 4)
```bash
$ lcov \
    --add-tracefile lcov/zero-coverage \
    --add-tracefile lcov/coverage \
    --output-file lcov/total_coverage \
    --rc lcov_branch_coverage=1
```

6. Use `genhtml` to generate browsable coverage information
```bash
$ genhtml \
    --output-directory ./lcov/html" \
    "./lcov/total_coverage" \
    --prefix . \
    --legend \
    --demangle-cpp \
    --rc genhtml_branch_coverage=1
```

7. Open the generate html: e.g.,
```bash
chromium-browser ./lcov/html/index.html
```

## Future Work
A `colcon coverage-results` command to wrap the `lcov` commands such that we can leverage the package selection extension of `colcon`?

cc @wjwwood 

## Reference
Close colcon/colcon-core#94