### PR TITLE
relax line length check

### DIFF
--- a/lint.py
+++ b/lint.py
@@ -23,7 +23,8 @@ for name in sorted(os.listdir()):
             'rules: {'
             'document-start: {present: false}, '
             'empty-lines: {max: 0}, '
-            'key-ordering: {}'
+            'key-ordering: {}, '
+            'line-length: {max: 999}'
             '}'
             '}',
             '--strict',


### PR DESCRIPTION
As noticed on #8 the default max line length is rather restrictive. Especially when a single argument can get lengthy.

Therefore this PR "drop" the restriction (kind of - yamllint doesn't allow to disable the check afaik so the limit is just much higher now).