### PR TITLE
Add thread sanitizer mixin

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -5,3 +5,4 @@ mixin:
   - ccache.mixin
   - coverage.mixin
   - test-linters.mixin
+  - tsan.mixin

--- a/tsan.mixin
+++ b/tsan.mixin
@@ -1,0 +1,10 @@
+{
+    "build": {
+        "tsan-gcc": {
+            "cmake-args": [
+                "-DCMAKE_C_FLAGS='-fsanitize=thread -O1 -g -fno-omit-frame-pointer'",
+                "-DCMAKE_CXX_FLAGS='-fsanitize=thread -O1 -g -fno-omit-frame-pointer'"
+            ]
+        }
+    }
+}

--- a/tsan.mixin
+++ b/tsan.mixin
@@ -2,8 +2,8 @@
     "build": {
         "tsan": {
             "cmake-args": [
-                "-DCMAKE_C_FLAGS='-fsanitize=thread -O1 -g -fno-omit-frame-pointer'",
-                "-DCMAKE_CXX_FLAGS='-fsanitize=thread -O1 -g -fno-omit-frame-pointer'"
+                "-DCMAKE_C_FLAGS='-fsanitize=thread -O2 -g -fno-omit-frame-pointer'",
+                "-DCMAKE_CXX_FLAGS='-fsanitize=thread -O2 -g -fno-omit-frame-pointer'"
             ]
         }
     }

--- a/tsan.mixin
+++ b/tsan.mixin
@@ -1,6 +1,6 @@
 {
     "build": {
-        "tsan-gcc": {
+        "tsan": {
             "cmake-args": [
                 "-DCMAKE_C_FLAGS='-fsanitize=thread -O1 -g -fno-omit-frame-pointer'",
                 "-DCMAKE_CXX_FLAGS='-fsanitize=thread -O1 -g -fno-omit-frame-pointer'"


### PR DESCRIPTION
* Add flags for nicer stack messages and filenames
* Add pthread flag to ensure successful asan build on Fast-RTPS. This change is to be removed once pthread is made a compulsory flag for Fast-RTPS linux builds. Issue link: https://github.com/eProsima/Fast-RTPS/issues/430

Connects to ros2/ci#254