### PR TITLE
Add mixin to force clang and libcxx

### DIFF
--- a/clang-libcxx.mixin
+++ b/clang-libcxx.mixin
@@ -1,5 +1,5 @@
 build:
-  libcxx:
+  clang-libcxx:
     cmake-args:
       - "-DCMAKE_C_COMPILER=clang"
       - "-DCMAKE_CXX_COMPILER=clang++"

--- a/index.yaml
+++ b/index.yaml
@@ -4,4 +4,5 @@ mixin:
   - build-type.mixin
   - ccache.mixin
   - coverage.mixin
+  - libcxx.mixin
   - test-linters.mixin

--- a/index.yaml
+++ b/index.yaml
@@ -3,6 +3,6 @@ mixin:
   - build-testing.mixin
   - build-type.mixin
   - ccache.mixin
+  - clang-libcxx.mixin
   - coverage.mixin
-  - libcxx.mixin
   - test-linters.mixin

--- a/libcxx.mixin
+++ b/libcxx.mixin
@@ -3,8 +3,7 @@ build:
     cmake-args:
       - "-DCMAKE_C_COMPILER=clang-6.0"
       - "-DCMAKE_CXX_COMPILER=clang++-6.0"
-      - "-DCMAKE_CXX_FLAGS=-stdlib=libc++ -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS"
+      - "-DCMAKE_CXX_FLAGS='-stdlib=libc++ -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS'"
       - "-DFORCE_BUILD_POCO=ON"
       - "-DFORCE_BUILD_TINYXML=ON"
       - "--no-warn-unused-cli"
-    merge-install: true

--- a/libcxx.mixin
+++ b/libcxx.mixin
@@ -4,6 +4,5 @@ build:
       - "-DCMAKE_C_COMPILER=clang-6.0"
       - "-DCMAKE_CXX_COMPILER=clang++-6.0"
       - "-DCMAKE_CXX_FLAGS='-stdlib=libc++ -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS'"
-      - "-DFORCE_BUILD_POCO=ON"
-      - "-DFORCE_BUILD_TINYXML=ON"
+      - "-DFORCE_BUILD_VENDOR_PKG=ON"
       - "--no-warn-unused-cli"

--- a/libcxx.mixin
+++ b/libcxx.mixin
@@ -1,0 +1,10 @@
+build:
+  libcxx:
+    cmake-args:
+      - "-DCMAKE_C_COMPILER=clang-6.0"
+      - "-DCMAKE_CXX_COMPILER=clang++-6.0"
+      - "-DCMAKE_CXX_FLAGS=-stdlib=libc++ -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS"
+      - "-DFORCE_BUILD_POCO=ON"
+      - "-DFORCE_BUILD_TINYXML=ON"
+      - "--no-warn-unused-cli"
+    merge-install: true

--- a/libcxx.mixin
+++ b/libcxx.mixin
@@ -1,8 +1,8 @@
 build:
   libcxx:
     cmake-args:
-      - "-DCMAKE_C_COMPILER=clang-6.0"
-      - "-DCMAKE_CXX_COMPILER=clang++-6.0"
+      - "-DCMAKE_C_COMPILER=clang"
+      - "-DCMAKE_CXX_COMPILER=clang++"
       - "-DCMAKE_CXX_FLAGS='-stdlib=libc++ -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS'"
       - "-DFORCE_BUILD_VENDOR_PKG=ON"
       - "--no-warn-unused-cli"


### PR DESCRIPTION
Edited up to date summary:

* Adds a mixin that performs the build using clang6, with LLVM's libcxx instead of gnu libstdc++
* Adding some CMake variables to force building some vendor packages

This mixin would be used on Clang CI build to enable Thread Safety Analysis, and generally validate that ROS2 works with libcxx

Related to:
- https://github.com/ros2/console_bridge_vendor/pull/4
- https://github.com/ros2/yaml_cpp_vendor/pull/4
- https://github.com/ros/pluginlib/pull/146
- https://github.com/ros2/tinyxml_vendor/pull/12
- https://github.com/ros2/rviz/pull/381
- https://github.com/ros2/poco_vendor/pull/24
- https://github.com/ros2/rclcpp/pull/648

Connects to https://github.com/ros2/ros2/issues/664