### PR TITLE
Add rel-min-size build mixin for building with CMAKE_BUILD_TYPE=MinSizeRel

### DIFF
--- a/build-type.mixin
+++ b/build-type.mixin
@@ -6,6 +6,9 @@
         "rel-with-deb-info": {
             "cmake-args": ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"]
         },
+        "rel-min-size": {
+            "cmake-args": ["-DCMAKE_BUILD_TYPE=RelMinSize"]
+        },
         "release": {
             "cmake-args": ["-DCMAKE_BUILD_TYPE=Release"]
         }

--- a/build-type.mixin
+++ b/build-type.mixin
@@ -7,7 +7,7 @@
             "cmake-args": ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"]
         },
         "rel-min-size": {
-            "cmake-args": ["-DCMAKE_BUILD_TYPE=RelMinSize"]
+            "cmake-args": ["-DCMAKE_BUILD_TYPE=MinRelSize"]
         },
         "release": {
             "cmake-args": ["-DCMAKE_BUILD_TYPE=Release"]

--- a/build-type.mixin
+++ b/build-type.mixin
@@ -3,7 +3,7 @@
         "debug": {
             "cmake-args": ["-DCMAKE_BUILD_TYPE=Debug"]
         },
-        "rel-min-size": {
+        "min-rel-size": {
             "cmake-args": ["-DCMAKE_BUILD_TYPE=MinRelSize"]
         },
         "rel-with-deb-info": {

--- a/build-type.mixin
+++ b/build-type.mixin
@@ -3,11 +3,11 @@
         "debug": {
             "cmake-args": ["-DCMAKE_BUILD_TYPE=Debug"]
         },
-        "rel-with-deb-info": {
-            "cmake-args": ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"]
-        },
         "rel-min-size": {
             "cmake-args": ["-DCMAKE_BUILD_TYPE=MinRelSize"]
+        },
+        "rel-with-deb-info": {
+            "cmake-args": ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"]
         },
         "release": {
             "cmake-args": ["-DCMAKE_BUILD_TYPE=Release"]

--- a/build-type.mixin
+++ b/build-type.mixin
@@ -3,8 +3,8 @@
         "debug": {
             "cmake-args": ["-DCMAKE_BUILD_TYPE=Debug"]
         },
-        "min-rel-size": {
-            "cmake-args": ["-DCMAKE_BUILD_TYPE=MinRelSize"]
+        "min-size-rel": {
+            "cmake-args": ["-DCMAKE_BUILD_TYPE=MinSizeRel"]
         },
         "rel-with-deb-info": {
             "cmake-args": ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"]


### PR DESCRIPTION


Related to https://github.com/colcon/colcon-cmake/issues/42