### PR TITLE
Use --coverage flag to include -lgcov

### DIFF
--- a/coverage.mixin
+++ b/coverage.mixin
@@ -2,8 +2,8 @@
     "build": {
         "coverage-gcc": {
             "cmake-args": [
-                "-DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage'",
-                "-DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage'"
+                "-DCMAKE_C_FLAGS='--coverage'",
+                "-DCMAKE_CXX_FLAGS='--coverage'"
             ]
         }
     }


### PR DESCRIPTION
As per the gcc docs:
> The option is a synonym for -fprofile-arcs -ftest-coverage (when compiling) and -lgcov (when linking).
https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#Instrumentation-Options

Context: https://github.com/colcon/colcon-mixin-repository/issues/19