### PR TITLE
add coverage-py mixin

### DIFF
--- a/coverage.mixin
+++ b/coverage.mixin
@@ -6,5 +6,13 @@
                 "-DCMAKE_CXX_FLAGS='--coverage'"
             ]
         }
+    },
+    "test": {
+        "coverage-py": {
+            "pytest-args": [
+                "--cov-report=term",
+            ],
+            "pytest-with-coverage": true,
+        }
     }
 }

--- a/coverage.mixin
+++ b/coverage.mixin
@@ -8,7 +8,7 @@
         }
     },
     "test": {
-        "coverage-py": {
+        "coverage-pytest": {
             "pytest-with-coverage": true,
         }
     }

--- a/coverage.mixin
+++ b/coverage.mixin
@@ -9,9 +9,6 @@
     },
     "test": {
         "coverage-py": {
-            "pytest-args": [
-                "--cov-report=term",
-            ],
             "pytest-with-coverage": true,
         }
     }


### PR DESCRIPTION
On top of passing `--pytest-with-coverage`, this also adds a print of the report to the terminal instead of only generating `xml` and `html` report.

@dirk-thomas would you be ok with adding the report to terminal by default ? If so I'm happy to remove it from here and add it at https://github.com/colcon/colcon-core/blob/af7fa089962a9e9a35926734e17b00cfb4c780a6/colcon_core/task/python/test/pytest.py#L94