### PR TITLE
include --cov-report=term into coverage-pytest

### DIFF
--- a/coverage.mixin
+++ b/coverage.mixin
@@ -9,7 +9,8 @@
     },
     "test": {
         "coverage-pytest": {
-            "pytest-with-coverage": true,
+            "pytest-args": ["--cov-report=term"],
+            "pytest-with-coverage": true
         }
     }
 }


### PR DESCRIPTION
Follow up of #21 since the default value got reverted in colcon/colcon-core#333.