### PR TITLE
Add build coverage-pytest mixin for ament_cmake

### DIFF
--- a/coverage.mixin
+++ b/coverage.mixin
@@ -5,6 +5,9 @@
                 "-DCMAKE_C_FLAGS='--coverage'",
                 "-DCMAKE_CXX_FLAGS='--coverage'"
             ]
+        },
+        "coverage-pytest": {
+            "ament-cmake-args": ["-DAMENT_CMAKE_PYTEST_WITH_COVERAGE=ON"]
         }
     },
     "test": {


### PR DESCRIPTION
Follow-up to https://github.com/ament/ament_cmake/pull/226, now that we can enable coverage for `pytest` tests in `ros.ament_cmake` packages.