### PR TITLE
add compile-commands mixin

### DIFF
--- a/compile-commands.mixin
+++ b/compile-commands.mixin
@@ -1,0 +1,10 @@
+{
+    "build": {
+        "compile-commands": {
+            "cmake-args": [
+                "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+                "--no-warn-unused-cli"
+            ]
+        }
+    }
+}

--- a/index.yaml
+++ b/index.yaml
@@ -4,6 +4,7 @@ mixin:
   - build-type.mixin
   - ccache.mixin
   - clang-libcxx.mixin
+  - compile-commands.mixin
   - coverage.mixin
   - test-linters.mixin
   - tsan.mixin


### PR DESCRIPTION
Passing the CMake arg `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` as well as `--no-warn-unused-cli` to suppress warnings for packages which don't support the option.