### PR TITLE
Add memcheck mixin for using valgrind with CMake

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -9,6 +9,7 @@ mixin:
   - gold.mixin
   - instrument-functions.mixin
   - lld.mixin
+  - memcheck.mixin
   - mold.mixin
   - ninja.mixin
   - test-linters.mixin

--- a/memcheck.mixin
+++ b/memcheck.mixin
@@ -1,0 +1,16 @@
+{
+    "build": {
+        "memcheck": {
+            "cmake-args": [
+                "-DMEMORYCHECK_COMMAND_OPTIONS=-q --tool=memcheck --leak-check=yes --num-callers=50 --error-exitcode=1"
+            ]
+        }
+    },
+    "test": {
+        "memcheck": {
+            "ctest-args": [
+                "-D", "ExperimentalMemCheck"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This mixin will cause CTest to run all tests a second time with Valgrind, and will fail the test if there are any critical memory problems detected.