### PR TITLE
Build all libraries as shared libraries

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -11,5 +11,6 @@ mixin:
   - lld.mixin
   - mold.mixin
   - ninja.mixin
+  - shared.mixin
   - test-linters.mixin
   - tsan.mixin

--- a/shared.mixin
+++ b/shared.mixin
@@ -1,0 +1,9 @@
+{
+    "build": {
+        "shared": {
+            "cmake-args": [
+                "-DBUILD_SHARED_LIBS=ON"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Tyler Weaver <tyler@picknik.ai>

This adds a mixin for building all libraries that don't specify a shared/static type as shared. This is useful when developing shared libraries (plugins) that depend on libraries that did not specify if they were shared/static. The reason is that if you link a static library into a shared library you will get the error about needing to build with the position independent code (PIC) flag on your dependencies (which is enabled by default on shared libraries).