### PR TITLE
Add mixin for Clang

### DIFF
--- a/clang.mixin
+++ b/clang.mixin
@@ -1,0 +1,5 @@
+build:
+  clang:
+    cmake-args:
+      - "-DCMAKE_C_COMPILER=clang"
+      - "-DCMAKE_CXX_COMPILER=clang++"

--- a/index.yaml
+++ b/index.yaml
@@ -3,6 +3,7 @@ mixin:
   - build-testing.mixin
   - build-type.mixin
   - ccache.mixin
+  - clang.mixin
   - clang-libcxx.mixin
   - compile-commands.mixin
   - coverage.mixin


### PR DESCRIPTION
It's useful to have a Mixin to switches to Clang with also pulling in libc++. This is useful for having access to things like Clang's compiler warnings and its `-ftime-trace` flag for measuring compile times. 

I also believe there are ABI considerations. By sticking to libstdc++ you can more assurance that you can link to 3rd party prebuilt libraries that contain standard library types in their interface.