### PR TITLE
Add time-trace mixin

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -17,3 +17,4 @@ mixin:
   - shared.mixin
   - test-linters.mixin
   - tsan.mixin
+  - time-trace.mixin

--- a/time-trace.mixin
+++ b/time-trace.mixin
@@ -1,0 +1,5 @@
+build:
+  time-trace:
+    cmake-args:
+      - "-DCMAKE_CXX_FLAGS='-ftime-trace'"
+      - "-DCMAKE_C_FLAGS='-ftime-trace'"


### PR DESCRIPTION
Adds a mixin for Clang's excellent `-ftime-trace` option that outputs a flame graph of your build profile for each object.

Very useful in conjunction with [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer) 🙂 